### PR TITLE
Platform Dependent DLL support

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -40,6 +40,24 @@ module.exports = {
         follow: true,
       });
 
+      var generateFileName = function(path) {
+
+          //see https://github.com/aws/aws-lambda-dotnet/blob/master/Libraries/src/Amazon.Lambda.Tools/DotNetCLIWrapper.cs
+          const KNOWN_PLATFORM_DEPENDENCIES = [
+            "runtimes/unix/lib/netstandard1.3/System.Data.SqlClient.dll",
+            "runtimes/unix/lib/netstandard1.3/System.IO.Pipes.dll",
+            "runtimes/unix/lib/netstandard1.3/System.Private.ServiceModel.dll"
+          ];
+
+          for(var c = 0; c < KNOWN_PLATFORM_DEPENDENCIES.length; c++) {
+            if(path.endsWith(KNOWN_PLATFORM_DEPENDENCIES[c])) {
+              return KNOWN_PLATFORM_DEPENDENCIES[c].substring(KNOWN_PLATFORM_DEPENDENCIES[c].lastIndexOf('/'), KNOWN_PLATFORM_DEPENDENCIES[c].length);
+            }
+          }
+
+          return path;
+      };
+
       files.forEach((filePath) => {
         const fullPath = path.resolve(
           sourcePath,
@@ -50,7 +68,7 @@ module.exports = {
 
         if (!stats.isDirectory(fullPath)) {
           zip.append(fs.readFileSync(fullPath), {
-            name: filePath,
+            name: generateFileName(filePath),
             mode: stats.mode,
           });
         }


### PR DESCRIPTION
Adding support to mimic how AWS's lambda tools packages platfrom dependent dll's up.

See FlattenKnownPlatformDependencies method at https://github.com/aws/aws-lambda-dotnet/blob/master/Libraries/src/Amazon.Lambda.Tools/DotNetCLIWrapper.cs.

