### PR TITLE
Add netcoreapp2.0 support

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -20,7 +20,7 @@ module.exports = {
       zipFileName
     );
 
-    const sourcePath = path.join(servicePath, 'bin/Release/netcoreapp1.0/publish/');
+    const sourcePath = path.join(servicePath, 'bin/Release/netcoreapp2.0/publish/');
 
     console.log(`Packaging application from '${sourcePath}' to '${artifactFilePath}'`);
 

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -20,7 +20,10 @@ module.exports = {
       zipFileName
     );
 
-    const sourcePath = path.join(servicePath, 'bin/Release/netcoreapp2.0/publish/');
+    const sourcePath = [
+      path.join(servicePath, 'bin/Release/netcoreapp1.0/publish/'),
+      path.join(servicePath, 'bin/Release/netcoreapp2.0/publish/')
+    ].find(fs.existsSync);
 
     console.log(`Packaging application from '${sourcePath}' to '${artifactFilePath}'`);
 


### PR DESCRIPTION
AWS quite recently announced .net core 2.0 support, so here's a PR to allow packaging of 2.0 apps.

I've kept it as preferential support for 1.0, so that this still works for existing users.