### PR TITLE
Allow building of solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,15 @@ plugins:
   - serverless-dotnet
 ```
 
-And that's all there is to it. From this point, `dotnet restore` and `dotnet publish` will run as part of each `serverless deploy` run and the output will be zipped into the `.serverless` folder of your service, as it would for other runtimes.
+If your `.cs` files are in your service's root folder, then that's all there is to it. From this point, `dotnet restore` and `dotnet publish` will run as part of each `serverless deploy` run and the output will be zipped into the `.serverless` folder of your service, as it would for other runtimes.
+
+If your files are contained in a solution folder (for ease of unit testing, for example), then you just need to add the following to the `custom` section of your config file (YAML shown):
+
+```yaml
+custom:
+  dotnet:
+    slndir: relative/path/to/project/folder
+```
 
 ## Note
 If you are using the `aws-csharp` service template, you will need to remove the following line from your `serverless.yml` file as these are not needed any more:

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const BbPromise = require('bluebird');
 const clean = require('./lib/clean');
 const compile = require('./lib/compile');
 const pack = require('./lib/pack');
+const path = require('path');
 
 class ServerlessDotNet {
   constructor(serverless, options) {
@@ -17,6 +18,12 @@ class ServerlessDotNet {
       compile,
       pack
     );
+
+        this.servicePath = this.serverless.config.servicePath;
+        this.customVars = this.serverless.variables.service.custom;
+        if ((this.customVars) && (this.customVars.dotnet) && (this.customVars.dotnet.slndir)) {
+            this.servicePath = path.join(this.serverless.config.servicePath, this.customVars.dotnet.slndir);
+        }
 
     this.hooks = {
       'before:deploy:createDeploymentArtifacts': () => BbPromise.bind(this)

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -9,8 +9,8 @@ module.exports = {
     this.serverless.cli.log('Serverless DotNet: Clean');
 
     let cleanupPaths = [
-        path.join(this.serverless.config.servicePath,'bin'),
-        path.join(this.serverless.config.servicePath,'obj')
+        path.join(this.servicePath,'bin'),
+        path.join(this.servicePath,'obj')
     ];
 
     return new BbPromise(function (resolve, reject) {

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -6,7 +6,7 @@ const program = require('child_process');
 
 module.exports = {
   compile() {
-    let servicePath = this.serverless.config.servicePath;
+    let servicePath = this.servicePath;
     this.serverless.cli.log('Serverless DotNet: Compile');
 
     return new BbPromise(function (resolve, reject) {

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -11,11 +11,11 @@ module.exports = {
     this.serverless.cli.log('Serverless DotNet: Pack');
 
     const patterns = ['**'];
-    let servicePath = this.serverless.config.servicePath;
+    let servicePath = this.servicePath;
     let zipFileName = `${this.serverless.service.service}.zip`;
 
     const artifactFilePath = path.join(
-      servicePath,
+      this.serverless.config.servicePath,
       '.serverless',
       zipFileName
     );


### PR DESCRIPTION
My lambdas are in a solution to facilitate unit testing. This PR lets you specify a `custom:dotnet:slndir` setting in your service config and build from within that project.

My editor made a bunch of indentation changes that I went back and undid, but then I couldn't make things squash, so hopefully you can just merge the PR as a single commit. Let me know if there's something else you'd like me to do. 

Thanks!