### PR TITLE
Support netcoreapp2.1

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -22,7 +22,8 @@ module.exports = {
 
     const sourcePath = [
       path.join(servicePath, 'bin/Release/netcoreapp1.0/publish/'),
-      path.join(servicePath, 'bin/Release/netcoreapp2.0/publish/')
+      path.join(servicePath, 'bin/Release/netcoreapp2.0/publish/'),
+      path.join(servicePath, 'bin/Release/netcoreapp2.1/publish/')
     ].find(fs.existsSync);
 
     console.log(`Packaging application from '${sourcePath}' to '${artifactFilePath}'`);


### PR DESCRIPTION
As per https://aws.amazon.com/about-aws/whats-new/2018/06/lambda-supports-dotnetcore-twopointone/