### PR TITLE
Add option to set configuration of dotnet publish

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ class ServerlessDotNet {
     this.serverless = serverless;
     this.options = options;
 
+    this.configuration = this.options.hasOwnProperty('configuration') ?
+    this.options.configuration :
+    'Release';
+
     Object.assign(
       this,
       clean,

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -9,6 +9,10 @@ module.exports = {
     let servicePath = this.serverless.config.servicePath;
     this.serverless.cli.log('Serverless DotNet: Compile');
 
+    this.serverless.cli.log(this.serverless.config.servicePath)
+
+    const configuration = this.configuration;
+
     return new BbPromise(function (resolve, reject) {
       try {
         console.log('Restoring packages for ' + servicePath);
@@ -23,7 +27,7 @@ module.exports = {
           }
 
           console.log('Publishing');
-          program.exec(`dotnet publish ${servicePath} -c Release /p:GenerateRuntimeConfigurationFiles=true`, function(error, stdout, stderr){
+          program.exec(`dotnet publish ${servicePath} -c ${configuration} /p:GenerateRuntimeConfigurationFiles=true`, function(error, stdout, stderr){
             console.log(stdout);
 
             if (error) {

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -21,9 +21,9 @@ module.exports = {
     );
 
     const sourcePath = [
-      path.join(servicePath, 'bin/Release/netcoreapp1.0/publish/'),
-      path.join(servicePath, 'bin/Release/netcoreapp2.0/publish/'),
-      path.join(servicePath, 'bin/Release/netcoreapp2.1/publish/')
+      path.join(servicePath, `bin/${this.configuration}/netcoreapp1.0/publish/`),
+      path.join(servicePath, `bin/${this.configuration}/netcoreapp2.0/publish/`),
+      path.join(servicePath, `bin/${this.configuration}/netcoreapp2.1/publish/`)
     ].find(fs.existsSync);
 
     console.log(`Packaging application from '${sourcePath}' to '${artifactFilePath}'`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-dotnet",
-  "version": "1.3.0",
+  "version": "1.5.0",
   "description": "A Serverless v1.0 plugin to build your C# lambda functions on deploy.",
   "main": "index.js",
   "author": "Fabien Ruffin",


### PR DESCRIPTION
User can now use `serverless package —configuration Debug` to change dotnet publish configuration