### PR TITLE
Enable package parameter

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -14,9 +14,12 @@ module.exports = {
     let servicePath = this.serverless.config.servicePath;
     let zipFileName = `${this.serverless.service.service}.zip`;
 
+    const artifactDirectoryPath = this.options.hasOwnProperty('package') ?
+      this.options.package : 
+      servicePath.join('.serverless');
+
     const artifactFilePath = path.join(
-      servicePath,
-      '.serverless',
+      artifactDirectoryPath,
       zipFileName
     );
 


### PR DESCRIPTION
Allow user to use `serverless package —package <directory_path>` to specify the directory in which the packaged Lambda function will be saved.