### PR TITLE
Remove servicePath does not have join() method bug

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -16,7 +16,7 @@ module.exports = {
 
     const artifactDirectoryPath = this.options.hasOwnProperty('package') ?
       this.options.package : 
-      servicePath.join('.serverless');
+      path.join(servicePath, '.serverless');
 
     const artifactFilePath = path.join(
       artifactDirectoryPath,


### PR DESCRIPTION
Use path.join instead of servicePath.join(), because servicePath.join() is not a function

Fixes #16 